### PR TITLE
code coverage, small api change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,16 @@ jobs:
         run: deno coverage --unstable --lcov ./cov > cov.lcov
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: coverallsapp/github-action@v1.1.2
         with:
-          token: ${{ secrets.codecov_token }}
-          files: ./cov.lcov # optional
-          fail_ci_if_error: true # optional (default = false)
-        env:
-          CODECOV_TOKEN: ${{ secrets.codecov_token }}
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: ./cov.lcov
+
+      # - name: Upload coverage
+      #   uses: codecov/codecov-action@v1
+      #   with:
+      #     token: ${{ secrets.codecov_token }}
+      #     files: ./cov.lcov # optional
+      #     fail_ci_if_error: true # optional (default = false)
+      #   env:
+      #     CODECOV_TOKEN: ${{ secrets.codecov_token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,10 @@ jobs:
         run: deno coverage --unstable --lcov ./cov > cov.lcov
 
       - name: Upload coverage
-        uses: coverallsapp/github-action@v1.1.2
+        uses: codecov/codecov-action@v1
         with:
-          github-token: ${{ secrets.codecov_token }}
-          path-to-lcov: ./cov.lcov
-          
+          files: ./cov.lcov # optional
+          name: codecov-umbrella # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+              

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
+          token: ${{ secrets.codecov_token }}
           files: ./cov.lcov # optional
           name: codecov-umbrella # optional
           fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main, coverage]
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -28,12 +28,3 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: ./cov.lcov
-
-      # - name: Upload coverage
-      #   uses: codecov/codecov-action@v1
-      #   with:
-      #     token: ${{ secrets.codecov_token }}
-      #     files: ./cov.lcov # optional
-      #     fail_ci_if_error: true # optional (default = false)
-      #   env:
-      #     CODECOV_TOKEN: ${{ secrets.codecov_token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,5 @@ jobs:
         with:
           token: ${{ secrets.codecov_token }}
           files: ./cov.lcov # optional
-          name: codecov-umbrella # optional
           fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)
               

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,13 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, coverage]
   pull_request:
     branches: [main]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: setup Actions
         uses: actions/checkout@v2
@@ -18,5 +18,14 @@ jobs:
           deno-version: v1.x
       - name: run tests
         run: |
-          deno test -A
+          deno test -A --coverage=./cov --unstable
+
+      - name: Generate lcov
+        run: deno coverage --unstable --lcov ./cov > cov.lcov
+
+      - name: Upload coverage
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.codecov_token }}
+          path-to-lcov: ./cov.lcov
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,5 @@ jobs:
           token: ${{ secrets.codecov_token }}
           files: ./cov.lcov # optional
           fail_ci_if_error: true # optional (default = false)
-              
+        env:
+          CODECOV_TOKEN: ${{ secrets.codecov_token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 autosorter/
+cov/
 benchmarks.ts

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ This module provides two fluent builder interfaces to make regex patterns. Regex
 - [PatternBuilder](#patternbuilder)  
    * [Templates](#templates)  
    * [Placeholders](#placeholders)  
-   * [Match Maps](#match-maps)
-   * [Automatic Mapping](#automatic-mapping)
-   * [Exceptions](#exceptions)  
-   * [Wildcard Pattern](#wildcard-pattern)
+   * [Match Maps](#match-maps-experimental)
+   * [Automatic Mapping](#automatic-mapping-experimental)
+   * [Exceptions](#exceptions-experimental)  
+   * [Wildcard Pattern](#wildcard-pattern-experimental)
    * [Custom Variable Symbol](#custom-variable-symbol)
    * [Custom Separator Symbol](#custom-separator) 
 
@@ -157,7 +157,7 @@ This can be shortened by using composite calls such as `nestAdd` to combine `nes
 
     .whitespace()   >> /\s/
 
-    .nonDigits()    >> /\D/
+    .nonDigit()    >> /\D/
     
     .any()          >> /./
 
@@ -261,7 +261,7 @@ Templates are useful to separate concerns between a pattern's structure and valu
         year: String.raw`(?:19|20)\d{2}\b`  // Note that you will need double backslashes in a normal string 
     })
 ```
-If the data you wish to match will have different formats it's also possible to define multiple templates and use `buildAll()` in place of `build()`. This will return an array of patterns. For example, if you are matching both American and European date formats:
+When the data you plan to match has different structures you can define multiple templates and use `buildAll()` instead of `build()`. This will return a list of patterns. For example, if you are matching both American and European date formats:
 ```typescript
     .settings({
         template: [
@@ -277,18 +277,15 @@ If the data you wish to match will have different formats it's also possible to 
     .buildAll();
 ```
 
-Picking a [template variable symbol](#custom-variable-symbol) is possible if you want to be more clear on which parts of a template are variables and which are not.
+Choosing a [template variable symbol](#custom-variable-symbol) is possible if you want to add more clarity on which parts of a template are variables and which aren't.
 
-When you don't need to use any settings and only want to define a template, you can also use `template` as a more concise route:
+When you only want to define a template and don't need to use any settings other, call `template()`:
 ```typescript
-Pattern.new()
     .template('(foo)(?!bar)')
-    .vars({ foo: 'bar', bar: 'baz'})
-    .build();
 ```
 
 ### Placeholders
-Declare a set of placeholder substitutes to reuse them in multiple patterns. Add placeholders to the data with double curly braces and a name: `{{placeholder}}`.
+Declare a set of placeholder substitutes to reuse them in multiple patterns. Adding placeholders to the data can be done with double curly braces and a name: `{{placeholder}}`.
 
 The example below shows how to reuse some of the data from the two previous patterns by using placeholders for `day`, `month` and `year`:
 ```typescript
@@ -339,7 +336,7 @@ const calendarDate = Pattern.new()
     ]
 ```
 
-### Match Maps
+### Match Maps (Experimental)
 Arrays of matches can be mapped to their pattern's template with the `matchMap` method:
 ```typescript
     .settings({ template: '(greeting) (region)' })
@@ -353,7 +350,7 @@ pattern.matchMap('hello world')
 >> { full_match: 'hello world', greeting: 'hello', region: 'world' }
 ```
 
-### Automatic Mapping
+### Automatic Mapping (Experimental)
 When the `map: true` setting is used a pattern will automatically map the array of matches.
 ```typescript
 let pattern = Pattern.new()
@@ -366,7 +363,7 @@ console.log(pattern.match('bar'));
 >> { full_match: 'bar', foo: 'bar' }
 ```
 
-### Exceptions
+### Exceptions (Experimental)
 Separate desired and unwanted values with the `filter` method. Note that this will restructure your template as `exclude|({the-rest-of-the-template})` and _place any desired full match in capture group 1_ while adding unwanted values to group 0 only.
 ```typescript
 .settings({ template: 'years'})
@@ -400,7 +397,7 @@ Below is another example of filtering that allows matching two digits that repre
     // matches: ['32'], no index 1 or higher
 ```
 
-### Wildcard Pattern
+### Wildcard Pattern (Experimental)
 Add a wildcard to be searched for after a set of known values. Note that this will restructure your template as `{the-rest-of-the-template}|(wildcard)`, adding a capture group but not changing the order of existing ones.
 ```typescript
 .settings({ template: 'years' })

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![build](https://github.com/GJZwiers/regexbuilder-deno/workflows/Build/badge.svg)
-[![codecov](https://codecov.io/gh/GJZwiers/regexbuilder-deno/branch/main/graph/badge.svg?token=W7JCODM23K)](https://codecov.io/gh/GJZwiers/regexbuilder-deno)
+[![Coverage Status](https://coveralls.io/repos/github/GJZwiers/regexbuilder-deno/badge.svg?branch=coverage)](https://coveralls.io/github/GJZwiers/regexbuilder-deno?branch=coverage)
 
 This module provides two fluent builder interfaces to make regex patterns. RegexBuilder is used for piecewise building of a RegExp, while PatternBuilder is used to create extended regexes from string templates defined by the user.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![build](https://github.com/GJZwiers/regexbuilder-deno/workflows/Build/badge.svg)
+[![codecov](https://codecov.io/gh/GJZwiers/regexbuilder-deno/branch/main/graph/badge.svg?token=W7JCODM23K)](https://codecov.io/gh/GJZwiers/regexbuilder-deno)
 
 This module provides two fluent builder interfaces to make regex patterns. RegexBuilder is used for piecewise building of a RegExp, while PatternBuilder is used to create extended regexes from string templates defined by the user.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module provides two fluent builder interfaces to make regex patterns. Regex
    * [Templates](#templates)  
    * [Placeholders](#placeholders)  
    * [Match Maps](#match-maps-experimental)
-   * [Automatic Mapping](#automatic-mapping-experimental)
+   <!-- * [Automatic Mapping](#automatic-mapping-experimental) -->
    * [Exceptions](#exceptions-experimental)  
    * [Wildcard Pattern](#wildcard-pattern-experimental)
    * [Custom Variable Symbol](#custom-variable-symbol)
@@ -351,7 +351,7 @@ pattern.matchMap('hello world')
 >> { full_match: 'hello world', greeting: 'hello', region: 'world' }
 ```
 
-### Automatic Mapping (Experimental)
+<!-- ### Automatic Mapping (Experimental)
 When the `map: true` setting is used a pattern will automatically map the array of matches.
 ```typescript
 let pattern = Pattern.new()
@@ -362,7 +362,7 @@ let pattern = Pattern.new()
 console.log(pattern.match('bar'));
 
 >> { full_match: 'bar', foo: 'bar' }
-```
+``` -->
 
 ### Exceptions (Experimental)
 Separate desired and unwanted values with the `filter` method. Note that this will restructure your template as `exclude|({the-rest-of-the-template})` and _place any desired full match in capture group 1_ while adding unwanted values to group 0 only.

--- a/extended-regexp/extended_regexp.ts
+++ b/extended-regexp/extended_regexp.ts
@@ -1,4 +1,4 @@
-import { TemplateBracketHandler, TemplateStringHandler } from "../template-group-handler/template_string_handler.ts";
+import { TemplateBracketHandler } from "../template-group-handler/template_string_handler.ts";
 
 export interface RegExpMatchMap {
     full_match: string,
@@ -115,10 +115,5 @@ export class ExtendedRegExp {
             map[name] = matches[i + 1];
         }
         return map;
-    }
-
-    static nests(str: string) {
-        const results = new TemplateStringHandler(str, '(').extractTemplateGroups();
-        console.log(results);
     }
 }

--- a/extended-regexp/extended_regexp_test.ts
+++ b/extended-regexp/extended_regexp_test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertObjectMatch, assertThrows } from "https://deno.land
 import { ExtendedRegExp, RegExpMatchMap } from "./extended_regexp.ts";
 
 Deno.test("ExtendedRegExp - provides throughput to RegExp properties", () => {
-    const xregex = new ExtendedRegExp(/bar/, 'foo', false);
+    const xregex = new ExtendedRegExp(/bar/, 'foo');
     assertEquals(xregex.global, false);
     assertEquals(xregex.dotAll, false);
     assertEquals(xregex.global, false);
@@ -21,7 +21,7 @@ Deno.test("ExtendedRegExp - provides throughput to RegExp properties", () => {
 
 });
 Deno.test("ExtendedRegExp - provides throughput to RegExp methods", () => {
-    const xregex = new ExtendedRegExp(/bar/, 'foo', false);
+    const xregex = new ExtendedRegExp(/bar/, 'foo');
     assertEquals(xregex.test('bar'), true);
     assertEquals(xregex.exec('bar'), /bar/.exec('bar'));
     assertEquals(xregex.match('bar'), 'bar'.match(/bar/));
@@ -29,7 +29,7 @@ Deno.test("ExtendedRegExp - provides throughput to RegExp methods", () => {
     assertEquals(xregex.search('bar'), 'bar'.search('bar'));
     assertEquals(xregex.split('bar'), 'bar'.split('bar'));
 
-    const xregexGlobal = new ExtendedRegExp(/bar/g, 'foo', false);
+    const xregexGlobal = new ExtendedRegExp(/bar/g, 'foo');
     assertEquals(xregexGlobal.matchAll('bar'), 'bar'.matchAll(/bar/g));
 });
 // Deno.test("ExtendedRegExp - automaps correctly", () => {
@@ -38,21 +38,21 @@ Deno.test("ExtendedRegExp - provides throughput to RegExp methods", () => {
 //     const xregex2 = new ExtendedRegExp(/bar/, 'foo', true);
 // });
 Deno.test("ExtendedRegExp - gets template correctly", () => {
-    const xregex = new ExtendedRegExp(/bar/, 'foo', true);
+    const xregex = new ExtendedRegExp(/bar/, 'foo');
     assertEquals(xregex.getTemplate(), 'foo');
 });
 Deno.test("ExtendedRegExp - maps matches with no capturing groups", () => {
-    const xregex = new ExtendedRegExp(/bar/, 'foo', false);
+    const xregex = new ExtendedRegExp(/bar/, 'foo');
     const map = xregex.map(['bar']);
     assertEquals(map, {full_match: 'bar'});
 });
 Deno.test("ExtendedRegExp - maps matches with capturing groups", () => {
-    const xregex = new ExtendedRegExp(/(bar)/, '(foo)', false);
+    const xregex = new ExtendedRegExp(/(bar)/, '(foo)');
     const map = xregex.map(['bar', 'bar']);
     assertObjectMatch(map, {foo: 'bar'});
 });
 Deno.test("ExtendedRegExp - maps matches with nested capturing groups", () => {
-    const xregex = new ExtendedRegExp(/((foo)bar)/, '((bar)foo)', false);
+    const xregex = new ExtendedRegExp(/((foo)bar)/, '((bar)foo)');
     const map = xregex.map(['foobar', 'foobar', 'foo']);
     assertObjectMatch(map, {bar: 'foo', foo: 'foobar'});
 });
@@ -62,7 +62,7 @@ Deno.test("ExtendedRegExp - maps matches with nested capturing groups", () => {
 //     assertObjectMatch(<RegExpMatchMap>map, {full_match: 'bar', foo: 'bar'});
 // });
 Deno.test("ExtendedRegExp - throws error on mapping template with unnamed capturing group (added with filter method)", () => {
-    const xregex = new ExtendedRegExp(/filter|((bar))/, 'filter|((foo))', false);
+    const xregex = new ExtendedRegExp(/filter|((bar))/, 'filter|((foo))');
     assertThrows(() => {
         return xregex.matchMap('bar');
     });

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,3 @@
 export { Regex } from './regexbuilder/regex.ts';
 export { Pattern } from './patternbuilder/pattern.ts';
-export * from './extended-regexp/extended_regexp.ts';
+export { ExtendedRegExp} from './extended-regexp/extended_regexp.ts';

--- a/patternbuilder/patternbuilder_test.ts
+++ b/patternbuilder/patternbuilder_test.ts
@@ -15,7 +15,7 @@ Deno.test("PatternBuilder - builds pattern from template string and variables co
         .vars({foo: 'bar'})
         .build();
 
-    assertEquals(pattern, new ExtendedRegExp(/bar/, 'foo', false));
+    assertEquals(pattern, new ExtendedRegExp(/bar/, 'foo'));
 });
 
 Deno.test("PatternBuilder - builds pattern from template string and variables correctly using deprecated method", () => {
@@ -24,7 +24,7 @@ Deno.test("PatternBuilder - builds pattern from template string and variables co
         .data({foo: 'bar'})
         .build();
 
-    assertEquals(pattern, new ExtendedRegExp(/bar/, 'foo', false));
+    assertEquals(pattern, new ExtendedRegExp(/bar/, 'foo'));
 });
 
 Deno.test("PatternBuilder - handles placeholders correctly", () => {
@@ -34,7 +34,7 @@ Deno.test("PatternBuilder - handles placeholders correctly", () => {
         .placeholders({bar: 'baz'})
         .build();
 
-    assertEquals(pattern, new ExtendedRegExp(/baz/, 'foo', false));
+    assertEquals(pattern, new ExtendedRegExp(/baz/, 'foo'));
 });
 
 Deno.test("PatternBuilder - builds pattern from template and vars correctly using the template() shorthand", () => {
@@ -43,7 +43,7 @@ Deno.test("PatternBuilder - builds pattern from template and vars correctly usin
         .vars({foo: 'bar'})
         .build();
 
-    assertEquals(pattern, new ExtendedRegExp(/bar/, 'foo', false));
+    assertEquals(pattern, new ExtendedRegExp(/bar/, 'foo'));
 });
 
 Deno.test("PatternBuilder - adds exception group correctly", () => {
@@ -52,14 +52,14 @@ Deno.test("PatternBuilder - adds exception group correctly", () => {
         .vars({foo: 'bar'})
         .filter('baz')
         .build();
-    assertEquals(pattern, new ExtendedRegExp(/baz|(bar)/, 'filter|(foo)', false));
+    assertEquals(pattern, new ExtendedRegExp(/baz|(bar)/, 'filter|(foo)'));
 
     const pattern2 = Pattern.new()
         .settings({template: 'foo'})
         .vars({foo: 'bar'})
         .except('baz')
         .build();
-    assertEquals(pattern2, new ExtendedRegExp(/baz|(bar)/, 'filter|(foo)', false));
+    assertEquals(pattern2, new ExtendedRegExp(/baz|(bar)/, 'filter|(foo)'));
 });
 
 Deno.test("PatternBuilder - adds wildcard group correctly", () => {
@@ -69,7 +69,7 @@ Deno.test("PatternBuilder - adds wildcard group correctly", () => {
         .wildcard('b.*')
         .build();
 
-    assertEquals(pattern, new ExtendedRegExp(/bar|(b.*)/, 'foo|(wildcard)', false));
+    assertEquals(pattern, new ExtendedRegExp(/bar|(b.*)/, 'foo|(wildcard)'));
 });
 
 Deno.test("PatternBuilder - returns multiple extended regexes on receiving multiple templates correctly", () => {
@@ -78,15 +78,15 @@ Deno.test("PatternBuilder - returns multiple extended regexes on receiving multi
         .vars({foo: 'bar'})
         .buildAll();
 
-    assertArrayIncludes(pattern, [new ExtendedRegExp(/bar/, 'foo', false), new ExtendedRegExp(/baz/, 'baz', false)]);
+    assertArrayIncludes(pattern, [new ExtendedRegExp(/bar/, 'foo'), new ExtendedRegExp(/baz/, 'baz')]);
 });
 
-Deno.test("PatternBuilder - adds wildcard group correctly", () => {
-    const pattern = Pattern.new()
-        .settings({template: '(foo)', map: true})
-        .vars({foo: 'bar'})
-        .build();
+// Deno.test("PatternBuilder - adds wildcard group correctly", () => {
+//     const pattern = Pattern.new()
+//         .settings({template: '(foo)', map: true})
+//         .vars({foo: 'bar'})
+//         .build();
 
-    assertEquals(pattern, new ExtendedRegExp(/(bar)/, '(foo)', true));
-    assertEquals(pattern.match('bar'), {full_match: 'bar', foo: 'bar'});
-});
+//     assertEquals(pattern, new ExtendedRegExp(/(bar)/, '(foo)'));
+//     assertEquals(pattern.match('bar'), {full_match: 'bar', foo: 'bar'});
+// });

--- a/patternbuilder/patterncrafter.ts
+++ b/patternbuilder/patterncrafter.ts
@@ -11,8 +11,7 @@ class PatternCrafter {
             new RegExp(
                 this.spec.compose(template), 
                 this.data.settings.flags ?? ''),
-            template,
-            this.data.settings.map ?? false);
+            template);
         });
     }
 }

--- a/regexbuilder/regex_builder_base.ts
+++ b/regexbuilder/regex_builder_base.ts
@@ -1,6 +1,6 @@
 import { Regex } from "./regex.ts";
 
-export class RegexBuilderBase {
+export abstract class RegexBuilderBase {
     regex: Regex = new Regex();
     nests = 0;
     /** Finishes construction of a regular expression using the builder and returns the regex built. */


### PR DESCRIPTION
This PR uses the new Deno options to output a `.lcov` file with a code coverage report and sends it to the Coveralls service. Furthermore, a small change was made to the API for mapping matches, which is now done exclusively with the `matchMap` method instead of a setting that changed the behavior of `match`